### PR TITLE
[Fix] Make zone redundancy the default

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/README.md
+++ b/README.md
@@ -13,19 +13,21 @@ This is the web hosting environment (App Service Environment) resource module fo
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.71)
 
-- <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0)
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
 
 ## Providers
 
 The following providers are used by this module:
 
-- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.71.0)
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 3.71)
 
-- <a name="provider_random"></a> [random](#provider\_random) (>= 3.5.0)
+- <a name="provider_random"></a> [random](#provider\_random) (~> 3.5)
 
 ## Resources
 
@@ -215,11 +217,11 @@ Default: `null`
 
 ### <a name="input_zone_redundant"></a> [zone\_redundant](#input\_zone\_redundant)
 
-Description: Specifies if the App Service Environment is zone redundant. Defaults to false. Set to true to deploy the ASEv3 with availability zones supported. Zonal ASEs can be deployed in some regions
+Description: Specifies if the App Service Environment is zone redundant. Defaults to true. Zonal ASEs can only be deployed in some regions
 
 Type: `bool`
 
-Default: `null`
+Default: `true`
 
 ## Outputs
 

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18.0"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,13 +1,17 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = "~> 1.5"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.71.0"
+      version = "~> 3.71"
+    }
+    modtm = {
+      source  = "azure/modtm"
+      version = "~> 0.3"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.5.0"
+      version = "~> 3.5"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,6 @@ variable "tags" {
 
 variable "zone_redundant" {
   type        = bool
-  default     = null
-  description = "Specifies if the App Service Environment is zone redundant. Defaults to false. Set to true to deploy the ASEv3 with availability zones supported. Zonal ASEs can be deployed in some regions"
+  default     = true
+  description = "Specifies if the App Service Environment is zone redundant. Defaults to true. Zonal ASEs can only be deployed in some regions"
 }


### PR DESCRIPTION
## Description
- Update TF docs version to 0.18
- Update TF providers 
- Update zone redundancy variable default to true

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
